### PR TITLE
Update cache.php - bug with html encode/decode

### DIFF
--- a/lastfmapi/class/cache.php
+++ b/lastfmapi/class/cache.php
@@ -160,7 +160,7 @@ class lastfmApiCache {
 	 */
 	public function get($unique_vars) {
 		if ( $this->enabled == true ) {
-			$query = "SELECT expires, body FROM cache WHERE unique_vars='".htmlentities(serialize($unique_vars))."' LIMIT 1";
+			$query = "SELECT expires, body FROM cache WHERE unique_vars='".htmlentities(serialize($unique_vars), ENT_COMPAT, 'UTF-8')."' LIMIT 1";
 			if ( $result = $this->db->query($query) ) {
 				if ( $result->size() > 0 ) {
 					$row = $result->fetch();
@@ -169,8 +169,8 @@ class lastfmApiCache {
 						return false;
 					}
 					else {
-						//print_r(unserialize(html_entity_decode($row['body'])));
-						return unserialize(html_entity_decode($row['body']));
+						//print_r(unserialize(html_entity_decode($row['body'], ENT_COMPAT, 'UTF-8')));
+						return unserialize(html_entity_decode($row['body'], ENT_COMPAT, 'UTF-8'));
 					}
 				}
 				else {
@@ -197,7 +197,7 @@ class lastfmApiCache {
 	public function set($unique_vars,  $body) {
 		if ( $this->enabled == true ) {
 			$expire = time() + $this->config['cache_length'];
-			$query = "INSERT INTO cache (unique_vars, expires, body) VALUES ('".htmlentities(serialize($unique_vars))."', '".$expire."', \"".htmlentities(serialize($body))."\")";
+			$query = "INSERT INTO cache (unique_vars, expires, body) VALUES ('".htmlentities(serialize($unique_vars), ENT_COMPAT, 'UTF-8')."', '".$expire."', \"".htmlentities(serialize($body), ENT_COMPAT, 'UTF-8')."\")";
 			if ( $this->db->query($query) ) {
 				return true;
 			}
@@ -218,7 +218,7 @@ class lastfmApiCache {
 	 * @return boolean
 	 */
 	private function del($unique_vars) {
-		$query = "DELETE FROM cache WHERE unique_vars='".htmlentities(serialize($unique_vars))."'";
+		$query = "DELETE FROM cache WHERE unique_vars='".htmlentities(serialize($unique_vars), ENT_COMPAT, 'UTF-8')."'";
 		if ( $this->db->query($query) ) {
 			return true;
 		}


### PR DESCRIPTION
Hello, i add second (ENT_COMPAT) and third ('UTF-8') argument to htmlentities/html_entity_decode action with data. This allow serialize/unserialize correct, with chars like Japanese, Polish and etc. 
